### PR TITLE
typo: Fix missing 'With' in cloneWith and cloneDeepWith

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10785,7 +10785,7 @@ declare namespace _ {
          * console.log(shallow[0] === objects[0]);
          * // => true
          */
-        clone<T>(
+        cloneWith<T>(
             value: T,
             customizer: (value: any) => any): T;
     }
@@ -10794,7 +10794,7 @@ declare namespace _ {
         /**
          * @see _.clone
          */
-        clone(customizer: (value: any) => any): T;
+        cloneWith(customizer: (value: any) => any): T;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
@@ -10802,14 +10802,14 @@ declare namespace _ {
         /**
          * @see _.clone
          */
-        clone(customizer: (value: any) => any): T[];
+        cloneWith(customizer: (value: any) => any): T[];
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
          * @see _.clone
          */
-        clone(customizer: (value: any) => any): T;
+        cloneWith(customizer: (value: any) => any): T;
     }
 
     //_.cloneDeepWith
@@ -10826,7 +10826,7 @@ declare namespace _ {
          * @param thisArg The this binding of customizer.
          * @return Returns the deep cloned value.
          */
-        cloneDeep<T>(
+        cloneDeepWith<T>(
             value: T,
             customizer: (value: any) => any): T;
     }
@@ -10835,21 +10835,21 @@ declare namespace _ {
         /**
          * @see _.cloneDeep
          */
-        cloneDeep(customizer: (value: any) => any): T;
+        cloneDeepWith(customizer: (value: any) => any): T;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
         /**
          * @see _.cloneDeep
          */
-        cloneDeep(customizer: (value: any) => any): T[];
+        cloneDeepWith(customizer: (value: any) => any): T[];
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
          * @see _.cloneDeep
          */
-        cloneDeep(customizer: (value: any) => any): T;
+        cloneDeepWith(customizer: (value: any) => any): T;
     }
 
     //_.eq


### PR DESCRIPTION
This just fixes a typo with the `clone`/`cloneWith` and `cloneDeep`/`cloneDeepWith` method names in the latest version of the definition.
