### PR TITLE
Fix _.fromPairs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -195,7 +195,7 @@ Methods:
 - [ ] _.differenceBy
 - [ ] _.differenceWith
 - [ ] _.flatMap
-- [ ] _.fromPairs
+- [x] _.fromPairs
 - [ ] _.intersectionBy
 - [ ] _.intersectionWith
 - [ ] _.join
@@ -2034,7 +2034,7 @@ declare namespace _ {
     flattenDeep<T>(): LoDashExplicitArrayWrapper<T>;
   }
 
-  // _.fromPairs DUMMY
+  // _.fromPairs
   interface LoDashStatic {
     /**
      * The inverse of `_.toPairs`; this method returns an object composed
@@ -2050,9 +2050,9 @@ declare namespace _ {
      * _.fromPairs([['fred', 30], ['barney', 40]]);
      * // => { 'fred': 30, 'barney': 40 }
      */
-    fromPairs(
-      array: any[] | List<any>
-    ): any[];
+    fromPairs<T>(
+      array: Array<[string, T]> | List<[string, T]>
+    ): Dictionary<T>;
   }
 
   // _.head


### PR DESCRIPTION
[_.fromPairs documentation](https://lodash.com/docs#fromPairs)

The return value is a dictionary, not an array.
Also, the argument can be better typed as `Array<[string, T]>` to reflect the expected pairs.

The inverse method (_.toPairs) is currently not wrong but could be typed more strictly with the return `Array<[string, T]>`. I left this out but I can add it to this PR if you want.
